### PR TITLE
docs: fix typos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 - supports injecting extra plugs
 - supports versioning 
   - by matching on assigns `api_version` field
-  - by targetting controllers
+  - by targeting controllers
   - by chaining routers
 - parameter marshalling support
   - path

--- a/lib/apical.ex
+++ b/lib/apical.ex
@@ -113,7 +113,7 @@ defmodule Apical do
   - `controller`:  Plug module which contains code implementing the API.
 
     It is recommended to `use Phoenix.Controller` in this plug module, or the
-    functions may or may not be targetted as expected.
+    functions may or may not be targeted as expected.
 
     Controller modules should implement public functions corresponding to the
     `operationId` of each operation in the schema.  These functions must be
@@ -127,7 +127,7 @@ defmodule Apical do
     > ### Important {: .warning }
     >
     > Unlike standard Phoenix controller functions, parameters declared in the
-    > `parameters` list of the operation are made avaliable in the `params`
+    > `parameters` list of the operation are made available in the `params`
     > argument as well as in `conn.params`.  These parameters will overwrite
     > any fields present in body parameters that happen to have the same name.
 

--- a/test/request_body/other_test.exs
+++ b/test/request_body/other_test.exs
@@ -150,7 +150,7 @@ defmodule ApicalTest.RequestBody.OtherTest do
   end
 
   describe "when content-type is declared by operation_id" do
-    test "the fully generic conent-type is accepted when it doesn't match", %{conn: conn} do
+    test "the fully generic content-type is accepted when it doesn't match", %{conn: conn} do
       assert "application specific" =
                do_post(conn, "/operation-parser", "foo", "application/x-foo")
     end


### PR DESCRIPTION
Found via `typos --format brief`