### PR TITLE
support operationId that specifies a module name and function

### DIFF
--- a/test/plug/operation_mf_test.exs
+++ b/test/plug/operation_mf_test.exs
@@ -1,0 +1,43 @@
+defmodule ApicalTest.Plug.Operation.Module do
+  use ApicalTest.EndpointCase, with: Plug
+  alias Plug.Conn
+
+  use Apical.Plug.Controller
+
+  def fun(conn, _params) do
+    Conn.send_resp(conn, 200, "OK")
+  end
+
+  test "GET /" do
+    assert %{
+             status: 200,
+             body: "OK"
+           } = Req.get!("http://localhost:#{@port}/")
+  end
+end
+
+defmodule ApicalTest.Plug.Operation.Module.Router do
+  use Apical.Plug.Router
+
+  require Apical
+
+  Apical.router_from_string(
+    """
+    openapi: 3.1.0
+    info:
+      title: TestGet
+      version: 1.0.0
+    paths:
+      "/":
+        get:
+          operationId: Module.fun
+          responses:
+            "200":
+              description: OK
+    """,
+    for: Plug,
+    root: "/",
+    controller: ApicalTest.Plug.Operation,
+    encoding: "application/yaml"
+  )
+end


### PR DESCRIPTION
I came across a spec with operation ids like `"operationId": "UtilController.change_email"` so needed this...